### PR TITLE
Remove the .git folder conditionally

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,9 @@
 # - you can set the git ref to deploy (can be a branch, tag or commit hash)
 project_version: "master"
 
+# For git, the .git folder is automatically removed
+project_remove_git_folder: true
+
 # If you use the "rsync" strategy:
 # - you can set a timeout for the synchonize module
 project_deploy_synchronize_timeout: 30

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,7 @@
 
 - name: Remove .git folder from new release folder
   file: "path={{ project_build_path }}/.git state=absent"
+  when: project_remove_git_folder
 
 - name: Run pre_build_commands in the build_path
   command: "{{ item }} chdir={{ project_build_path }}"


### PR DESCRIPTION
Use a variable to check whether the .git folder must be removed, in
some cases projects require to keep the .git folder and therefore an
option should be present to skip this task.

@ramondelafuente for some projects we currently rely on the version given back by `git describe`. Therefore, we need the .git folder to be available in the production deployment. I don't think so many ppl will need it, so I didn't update the README, but if required, I can document the variable.

The variable defaults to true, so BC is maintained.
