### PR TITLE
Fixed incorrect deployment strategy name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ the remote user to be able to clone the project (with SSH keys for example).
 
       vars:
         project_root: /home/deploy/
-        project_deploy_strategy: rsync
+        project_deploy_strategy: synchronize
 
       roles:
          - f500.project_deploy


### PR DESCRIPTION
The deployment strategy in the "Example Playbook" section in the README is set to 'rsync'.
The rsync strategy however does not exist and is called 'synchronize'.
