### PR TITLE
Optionally delete files that don't exist on source after synchronizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ you can set a timeout for the synchonize module
 
     project_deploy_synchronize_timeout: 30
 
+and you can also tell synchronize to delete files that don't exist on source:
+
+    project_deploy_synchronize_delete: true  # defaults to false
+
 you must set the path to your local source (default assumes the playbook in /ansible/)
 
     project_local_path: "../"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,8 @@ project_version: "master"
 # If you use the "rsync" strategy:
 # - you can set a timeout for the synchonize module
 project_deploy_synchronize_timeout: 30
+# - you can also delete files that don't exist on source after synchronizing
+project_deploy_synchronize_delete: false
 # - you must set the path to your local source (the default assumes your playbook is located in /ansible/ )
 project_local_path: "../"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
   when: project_deploy_strategy == 'git'
 
 - name: Rsync project files
-  synchronize: "src={{ project_local_path }} dest={{ project_source_path }} rsync_timeout={{ project_deploy_synchronize_timeout }} recursive=yes "
+  synchronize: "src={{ project_local_path }} dest={{ project_source_path }} rsync_timeout={{ project_deploy_synchronize_timeout }} delete={{ project_deploy_synchronize_delete }} recursive=yes "
   when: project_deploy_strategy == 'synchronize'
 
 - name: write unfinished file


### PR DESCRIPTION
When using the synchronize strategy, files deleted on the repo doesn't get removed from the target.
To support this functionality, an optional variable `project_deploy_synchronize_delete` is passed to the `synchronize` module.
