### PR TITLE
Add: disable/enable "sudo" mode for git.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@ project_deploy
 
 Deploy a project with Ansible
 
+### Changelog for this fork
+
+Pull request will be sent to original project maintainer: 
+
+- added "project_git_sudo" to connect to git with or without out *sudo* (defaults to false); see [GitHub Help](https://help.github.com/articles/error-permission-denied-publickey/) about this
+
+
+
 ### Changelog 2.1.0
 - added option to copy Composer, NPM and Bower folders from previous release
 
@@ -51,8 +59,15 @@ you can set the git ref to deploy (can be a branch, tag or commit hash), default
 
     project_version: "master"
 
+you can optionally use "sudo" mode to connect to git, if absolutely necessary:
+
+    project_git_sudo: true  # defaults to false
+
 When using the synchonize method, we recommend using a .rsync-filter file in the source folder,
 to exclude .git and other unneeded data to be transferred.
+
+
+
 
 If you use the "synchronize" strategy, you can set a timeout for the synchonize module:
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,9 @@
 # project_git_repo: "git_repository"
 # - you can set the git ref to deploy (can be a branch, tag or commit hash)
 project_version: "master"
+# - you can optionally use "sudo" to connect to git, if absolutely necessary;
+#   see https://help.github.com/articles/error-permission-denied-publickey/
+project_git_sudo: false
 
 # DEPRECATED
 # For git, the .git folder is automatically removed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,7 @@
   deploy_helper: "path={{ project_root }} state=present"
 
 - name: Clone project files
+  sudo: {{ project_git_sudo }}
   git: "repo={{ project_git_repo }} dest={{ project_source_path }} version={{ project_version }}"
   when: project_deploy_strategy == 'git'
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,10 +3,15 @@
 - name: Initialize
   deploy_helper: "path={{ project_root }} state=present"
 
-- name: Clone project files
-  sudo: {{ project_git_sudo }}
+- name: Clone project files without sudo
+  sudo: false
   git: "repo={{ project_git_repo }} dest={{ project_source_path }} version={{ project_version }}"
-  when: project_deploy_strategy == 'git'
+  when: project_deploy_strategy == 'git' and {{ project_git_sudo }} == false
+
+- name: Clone project files *with sudo*
+  sudo: true
+  git: "repo={{ project_git_repo }} dest={{ project_source_path }} version={{ project_version }}"
+  when: project_deploy_strategy == 'git' and {{ project_git_sudo }} == true
 
 - name: Rsync project files
   synchronize: "src={{ project_local_path }} dest={{ project_source_path }} rsync_timeout={{ project_deploy_synchronize_timeout }} delete={{ project_deploy_synchronize_delete }} recursive=yes "


### PR DESCRIPTION
Reason: in most cases "git" shouldn't be used with "sudo" mode.

I add a `project_git_sudo` variable to override "`sudo: true`" setting that may appear somewhere in user's main playbook, if any.

See [GitHub Help](https://help.github.com/articles/error-permission-denied-publickey/) about this:
> Should the sudo command be used with Git?
> You should not be using the sudo command with Git. If you have a very good reason you must use sudo, then [...]