### PR TITLE
Allow users to set shared path

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,14 @@ You can also change the path of the installed vendors (relative to {{ deploy_hel
     project_npm_modules_path: node_modules
     project_bower_components_path: components
 
+
+The project_shared_path is used to set the path for your shared assets. 
+Required: No
+Default: "{{ project_root }}/shared"
+
+    project_shared_path: "/var/data/example"
+
+
 All the files to copy to the remote system on deploy. These could contain config files:
 
     project_files: []
@@ -148,7 +156,7 @@ Works the same as the project_files:
     project_templates: []
 
 The shared_children is a list of all files/folders in your project that need to be linked to someplace outside
-the release. For example a logging directory or an uploads folder. These live in "/shared":
+the release. For example a logging directory or an uploads folder. These live in "{{ project_root }}/shared":
 
     project_shared_children: []
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Works the same as the project_files:
     project_templates: []
 
 The shared_children is a list of all files/folders in your project that need to be linked to someplace outside
-the release. For example a logging directory or an uploads folder. These live in "{{ project_root }}/shared":
+the release. For example a logging directory or an uploads folder. These live in "{{ project_shared_path }}":
 
     project_shared_children: []
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,6 +39,11 @@ project_s3_filename: my-app-master.war
 # you do not have to download/sync the entire project on every deploy
 project_source_path: "{{ project_root }}/shared/source"
 
+# The shared_path is used to set the path for your shared assets. 
+# Example:
+# project_shared_path: "/var/shared"
+project_shared_path: "{{ project_root }}/shared"
+
 # Files or folders to remove from the source when deploying
 project_unwanted_items: [ '.git' ]
 
@@ -92,7 +97,7 @@ project_files: []
 # Works the same as the project_files
 project_templates: []
 
-# The shared_children is a list of all files/folders in your project that need to be linked to a path in "/shared".
+# The shared_children is a list of all files/folders in your project that need to be linked to a path in "{{ project_shared_path }}.
 # For example a sessions directory or an uploads folder.. They are created if they don't exist, with the type
 # specified in the "type" key (file or directory).
 # Example:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Initialize
-  deploy_helper: "path={{ project_root }} state=present shared_path={{ project_shared_path|default(omit) }}"
+  deploy_helper: "path={{ project_root }} state=present shared_path={{ project_shared_path|default(project_shared_path) }}"
 
 - name: Clone project files
   git: "repo={{ project_git_repo }} dest={{ project_source_path }} version={{ project_version }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Initialize
-  deploy_helper: "path={{ project_root }} state=present"
+  deploy_helper: "path={{ project_root }} state=present shared_path={{ project_shared_path|default(omit) }}"
 
 - name: Clone project files
   git: "repo={{ project_git_repo }} dest={{ project_source_path }} version={{ project_version }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Initialize
-  deploy_helper: "path={{ project_root }} state=present shared_path={{ project_shared_path|default(project_shared_path) }}"
+  deploy_helper: "path={{ project_root }} state=present shared_path={{ project_shared_path }}"
 
 - name: Clone project files
   git: "repo={{ project_git_repo }} dest={{ project_source_path }} version={{ project_version }}"


### PR DESCRIPTION
This can be useful for users that have their shared folder in a different path. e.g.: Mounted NFS drive

How to use:
- name: Deploy the application
  hosts: prod

  vars:
    ...
    project_shared_path: "/var/data/example"