### PR TITLE
Added optional task includes with hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ project_deploy
 
 Deploy a project with Ansible
 
+### Changelog 2.2.0
+- added hooks. This feature allows for inclusion of arbitrary tasks at certain points in the process.
+
 ### Changelog 2.1.0
 - added option to copy Composer, NPM and Bower folders from previous release
 
@@ -43,6 +46,20 @@ These variables must be set, they have no defaults:
     project_root: "path_to_project_on_the_target_machine"
     project_deploy_strategy: "git", "synchronize" or "s3"
 
+At certain key points in the role an option exists to include a task file of your own.
+In order to use this option, create a tasks file and set the corresponding hook variable to its location:
+ 
+    project_deploy_hook_on_initialize
+    project_deploy_hook_on_update_source
+    project_deploy_hook_on_create_build_dir
+    project_deploy_hook_on_perform_build
+    project_deploy_hook_on_make_shared_resources
+    project_deploy_hook_on_finalize
+
+**Example:**
+
+    project_deploy_hook_on_perform_build: {{ playbook_dir }}/deploy_hooks/perform-build.yml
+    
 If you use the "git" strategy, you must also set a repository:
 
     project_git_repo: "git_repository"
@@ -178,6 +195,8 @@ The project_environment is a list of environment variables added to the various 
     project_environment:
       SYMFONY_ENV: "prod"
 
+
+**DEPRECATED, PLEASE USE HOOKS**
 There are a few moments in this role where arbitrary command(s) can be run. These commands receive
 the "project_environment" so deploys for different stages can be done by changing this:
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ In order to use this option, create a tasks file and set the corresponding hook 
 
 **Example:**
 
-    project_deploy_hook_on_perform_build: {{ playbook_dir }}/deploy_hooks/perform-build.yml
+    project_deploy_hook_on_perform_build: "{{ playbook_dir }}/deploy_hooks/perform-build.yml"
     
 If you use the "git" strategy, you must also set a repository:
 

--- a/tasks/hooks/example.yml
+++ b/tasks/hooks/example.yml
@@ -1,0 +1,16 @@
+# This is an example hook file
+# To use this, please refer to the README.md
+#
+# tl;dr
+#   1. create a tasks file you wish to include on a certain hook
+#
+#   2. set the "project_deploy_hook_on_[hook name]" variable to
+#       "{{ playbook_dir }}/path/to/tasks-file.yml"
+#
+#   Available hooks:
+#     - project_deploy_hook_on_initialize
+#     - project_deploy_hook_on_update_source
+#     - project_deploy_hook_on_create_build_dir
+#     - project_deploy_hook_on_perform_build
+#     - project_deploy_hook_on_make_shared_resources
+#     - project_deploy_hook_on_finalize

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,14 @@
 ---
 
+### Initialize
+- include: "{{ project_deploy_hook_on_initialize | default(lookup('pipe', 'pwd') ~ '/hooks/example.yml') }}"
+
 - name: Initialize
   deploy_helper: "path={{ project_root }} state=present shared_path={{ project_shared_path }}"
+
+
+### Update source
+- include: "{{ project_deploy_hook_on_update_source | default(lookup('pipe', 'pwd') ~ '/hooks/example.yml') }}"
 
 - name: Clone project files
   git: "repo={{ project_git_repo }} dest={{ project_source_path }} version={{ project_version }}"
@@ -18,6 +25,10 @@
 - name: write unfinished file
   file: "path={{ project_source_path }}/{{ deploy_helper.unfinished_filename }} state=touch"
 
+
+### Create build dir
+- include: "{{ project_deploy_hook_on_create_build_dir | default(lookup('pipe', 'pwd') ~ '/hooks/example.yml') }}"
+
 - name: Copy files to new build dir
   command: "cp -pr {{ project_source_path }} {{ deploy_helper.new_release_path }}"
 
@@ -32,6 +43,10 @@
 - name: Copy project templates
   template: src={{ item.src }} dest={{ deploy_helper.new_release_path }}/{{ item.dest }} mode={{ item.mode|default('0644') }}
   with_items: project_templates
+
+
+### Perform build
+- include: "{{ project_deploy_hook_on_perform_build | default(lookup('pipe', 'pwd') ~ '/hooks/example.yml') }}"
 
 - name: Run pre_build_commands in the new_release_path
   command: "{{ item }} chdir={{ deploy_helper.new_release_path }}"
@@ -80,6 +95,10 @@
   environment: project_environment
   when: project_has_bower
 
+
+### Make shared resources
+- include: "{{ project_deploy_hook_on_make_shared_resources | default(lookup('pipe', 'pwd') ~ '/hooks/example.yml') }}"
+
 - name: Ensure shared sources are present
   file: "path='{{ deploy_helper.shared_path }}/{{ item.src }}' state={{ item.type|default('directory') }}"
   with_items: project_shared_children
@@ -91,6 +110,10 @@
 - name: Create shared symlinks
   file: "path='{{ deploy_helper.new_release_path }}/{{ item.path }}' src='{{ deploy_helper.shared_path }}/{{ item.src }}' state=link"
   with_items: project_shared_children
+
+
+### Finalize
+- include: "{{ project_deploy_hook_on_finalize | default(lookup('pipe', 'pwd') ~ '/hooks/example.yml') }}"
 
 - name: Run post_build_commands in the new_release_path
   command: "{{ item }} chdir={{ deploy_helper.new_release_path }}"


### PR DESCRIPTION
At certain key points in the role an option exists to include a task file of your own.
In order to use this option, create a tasks file and set the corresponding hook variable to its location:
 
    project_deploy_hook_on_initialize
    project_deploy_hook_on_update_source
    project_deploy_hook_on_create_build_dir
    project_deploy_hook_on_perform_build
    project_deploy_hook_on_make_shared_resources
    project_deploy_hook_on_finalize

**Example:**

    project_deploy_hook_on_perform_build: "{{ playbook_dir }}/deploy_hooks/perform-build.yml"