### PR TITLE
Fix issue on ansible > 1.8.2 when ensuring a symlink shared source

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Deploy software projects (Capistrano-like)
   company: Future500
   license: LGPL
-  min_ansible_version: 1.4
+  min_ansible_version: 1.8
   platforms:
   - name: Debian
     versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -81,7 +81,7 @@
   when: project_has_bower
 
 - name: Ensure shared sources are present
-  file: "path='{{ deploy_helper.shared_path }}/{{ item.src }}' state={{ item.type|default('directory') }}"
+  file: "path='{{ deploy_helper.shared_path }}/{{ item.src }}' state={{ item.type|default('directory') }} follow=yes"
   with_items: project_shared_children
 
 - name: Ensure shared paths are absent


### PR DESCRIPTION
I recently found and issue while ensuring symlink paths on `project_shared_children` for ansible > 1.8.2

An example vanilla playbook, slightly modified from https://github.com/ansible/ansible-modules-core/pull/505#issuecomment-67673852

    - hosts: all
      gather_facts: no
      tasks:
        # prepare
        - file: path=/tmp/dir state=directory
        - file: path=/tmp/link src=/tmp/dir state=link

        # "follow" was added on ansible 1.8, and is the expected way to deal with symlink paths
        - file: path=/tmp/link state=directory follow=yes
        # this one works "incorrectly" with 1.8.2. The default `follow=no` value should fail as
        # the path in question is a symlink, not a dir
        - file: path=/tmp/link state=directory

The fix is trivial, but it raises the minimum required version to ansible >= 1.8

I tried to conditionally add the `follow=yes` option only for versions >= 1.8, but this variable was also added on 1.8.

Any plans to raise the role minimum ansible version? Do you have any suggestion?