### PR TITLE
Using full variable syntax for environment.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,7 +51,7 @@
 - name: Run pre_build_commands in the new_release_path
   command: "{{ item }} chdir={{ deploy_helper.new_release_path }}"
   with_items: project_pre_build_commands
-  environment: project_environment
+  environment: "{{ project_environment }}"
 
 - name: Check if vendor dir exists
   stat: path={{ deploy_helper.current_path }}/{{ project_composer_vendor_path }}
@@ -64,7 +64,7 @@
 
 - name: Do composer install
   command: "{{ project_command_for_composer_install }} chdir={{ deploy_helper.new_release_path }}"
-  environment: project_environment
+  environment: "{{ project_environment }}"
   when: project_has_composer
 
 - name: Check if npm dir exists
@@ -78,7 +78,7 @@
 
 - name: Do npm install
   command: "{{ project_command_for_npm_install }} chdir={{ deploy_helper.new_release_path }}"
-  environment: project_environment
+  environment: "{{ project_environment }}"
   when: project_has_npm
 
 - name: Check if bower dir exists
@@ -92,7 +92,7 @@
 
 - name: Do bower install
   command: "{{ project_command_for_bower_install }} chdir={{ deploy_helper.new_release_path }}"
-  environment: project_environment
+  environment: "{{ project_environment }}"
   when: project_has_bower
 
 
@@ -118,7 +118,7 @@
 - name: Run post_build_commands in the new_release_path
   command: "{{ item }} chdir={{ deploy_helper.new_release_path }}"
   with_items: project_post_build_commands
-  environment: project_environment
+  environment: "{{ project_environment }}"
 
 - name: Finalize the deploy
   deploy_helper: path={{ project_root }} release={{ deploy_helper.new_release }} state=finalize


### PR DESCRIPTION
This prevents errors and deprecation warnings after upgrading to ansible 2.

After updating to ansible 2 I got:

[DEPRECATION WARNING]: Using bare variables for environment is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{foo}}'). This feature will be removed in a future release. Deprecation warnings 
can be disabled by setting deprecation_warnings=False in ansible.cfg.                                                                                                                                                                              fatal: [host]: 

FAILED! => {"failed": true, "msg": "ERROR! environment must be a dictionary, received project_environment (<class 'ansible.parsing.yaml.objects.AnsibleUnicode'>)"}

Using full variable syntax fixed the errors

