### PR TITLE
Updated variables in tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,15 +40,15 @@
 
 - name: Remove unwanted files/folders from new release
   file: "path={{ deploy_helper.new_release_path }}/{{ item }} state=absent"
-  with_items: project_unwanted_items
+  with_items: "{{ project_unwanted_items }}"
 
 - name: Copy project files
   copy: src={{ item.src }} dest={{ deploy_helper.new_release_path }}/{{ item.dest }} mode={{ item.mode|default('0644') }}
-  with_items: project_files
+  with_items: "{{ project_files }}"
 
 - name: Copy project templates
   template: src={{ item.src }} dest={{ deploy_helper.new_release_path }}/{{ item.dest }} mode={{ item.mode|default('0644') }}
-  with_items: project_templates
+  with_items: "{{ project_templates }}"
 
 
 ### Perform build
@@ -58,13 +58,13 @@
 
 - name: Run pre_build_commands in the new_release_path
   command: "{{ item }} chdir={{ deploy_helper.new_release_path }}"
-  with_items: project_pre_build_commands
+  with_items: "{{ project_pre_build_commands }}"
   environment: "{{ project_environment }}"
 
 - name: Check if vendor dir exists
   stat: path={{ deploy_helper.current_path }}/{{ project_composer_vendor_path }}
   register: check_composer_vendor_path
-  when: project_copy_previous_composer_vendors
+  when: "{{ project_copy_previous_composer_vendors }}"
 
 - name: Copy vendor dir if exists to speed up composer
   command: /bin/cp -rp {{ deploy_helper.current_path }}/{{ project_composer_vendor_path }} {{ deploy_helper.new_release_path }}/{{ project_composer_vendor_path }}
@@ -73,12 +73,12 @@
 - name: Do composer install
   command: "{{ project_command_for_composer_install }} chdir={{ deploy_helper.new_release_path }}"
   environment: "{{ project_environment }}"
-  when: project_has_composer
+  when: "{{ project_has_composer }}"
 
 - name: Check if npm dir exists
   stat: path={{ deploy_helper.current_path }}/{{ project_npm_modules_path }}
   register: check_npm_modules_path
-  when: project_copy_previous_npm_modules
+  when: "{{ project_copy_previous_npm_modules }}"
 
 - name: Copy npm dir if exists to speed up npm install
   command: /bin/cp -rp {{ deploy_helper.current_path }}/{{ project_npm_modules_path }} {{ deploy_helper.new_release_path }}/{{ project_npm_modules_path }}
@@ -87,12 +87,12 @@
 - name: Do npm install
   command: "{{ project_command_for_npm_install }} chdir={{ deploy_helper.new_release_path }}"
   environment: "{{ project_environment }}"
-  when: project_has_npm
+  when: '{{ project_has_npm }}'
 
 - name: Check if bower dir exists
   stat: path={{ deploy_helper.current_path }}/{{ project_bower_components_path }}
   register: check_bower_components_path
-  when: project_copy_previous_bower_components
+  when: '{{ project_copy_previous_bower_components }}'
 
 - name: Copy bower dir if exists to speed up bower install
   command: /bin/cp -rp {{ deploy_helper.current_path }}/{{ project_bower_components_path }} {{ deploy_helper.new_release_path }}/{{ project_bower_components_path }}
@@ -101,7 +101,7 @@
 - name: Do bower install
   command: "{{ project_command_for_bower_install }} chdir={{ deploy_helper.new_release_path }}"
   environment: "{{ project_environment }}"
-  when: project_has_bower
+  when: "{{ project_has_bower }}"
 
 
 ### Make shared resources
@@ -111,15 +111,15 @@
 
 - name: Ensure shared sources are present
   file: "path='{{ deploy_helper.shared_path }}/{{ item.src }}' state={{ item.type|default('directory') }}"
-  with_items: project_shared_children
+  with_items: "{{ project_shared_children }}"
 
 - name: Ensure shared paths are absent
   file: "path='{{ deploy_helper.new_release_path }}/{{ item.path }}' state=absent"
-  with_items: project_shared_children
+  with_items: "{{ project_shared_children }}"
 
 - name: Create shared symlinks
   file: "path='{{ deploy_helper.new_release_path }}/{{ item.path }}' src='{{ deploy_helper.shared_path }}/{{ item.src }}' state=link"
-  with_items: project_shared_children
+  with_items: "{{ project_shared_children }}"
 
 
 ### Finalize
@@ -129,9 +129,9 @@
 
 - name: Run post_build_commands in the new_release_path
   command: "{{ item }} chdir={{ deploy_helper.new_release_path }}"
-  with_items: project_post_build_commands
+  with_items: "{{ project_post_build_commands }}"
   environment: "{{ project_environment }}"
 
 - name: Finalize the deploy
   deploy_helper: path={{ project_root }} release={{ deploy_helper.new_release }} state=finalize
-  when: project_finalize
+  when: "{{ project_finalize }}"


### PR DESCRIPTION
Version 2.0
> When specifying complex args as a variable, the variable must use the full jinja2 variable syntax ('{{var_name}}') - bare variable names there are no longer accepted. In fact, even specifying args with variables has been deprecated, and will not be allowed in future versions