### PR TITLE
Add "project_clean" and "project_keep_releases" variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ project_deploy
 
 Deploy a project with Ansible
 
+### Changelog 3.2.0
+
+- added the variables "project_clean" and "project_keep_releases".
+
 ### Changelog 3.1.1
 
 - Removed dependency on Ansible role `F500.project_deploy_module` (it is an Ansible Modules Extra module now)
@@ -248,6 +252,16 @@ When you're ready, perform the symlink task yourself (in post_tasks for example)
 When you're ready, finalize the deploy with the module:
 
     - deploy_helper: path={{ project_root }} release={{ deploy_helper.new_release }} state=finalize
+
+If you do want to finalize and have the role switch the "current" symlink, but
+don't want to clean up old releases, set "project_clean" to false:
+
+    project_clean: true
+
+Or if you want to keep less or more than 5 releases, set "project_keep_releases"
+to the desired number (minimum of 1):
+
+    project_keep_releases: 5
 
 
 Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -152,3 +152,11 @@ project_post_build_commands: []
 # - file: path={{ deploy.new_release_path }}/{{ deploy.unfinished_filename }} state=absent
 # - file: src={{ deploy.new_release_path }} dest={{ deploy.current_path }} state=link
 project_finalize: true
+
+# When finalizing, by default old releases will be cleanud up.
+# Set "project_clean" to false if you don't want this to happen.
+project_clean: true
+
+# When finalizing, by default old releases will be cleanud up. By default 5 release will be kept.
+# Set "project_keep_releases" when you want less or more release kept. Minimal is 1.
+project_keep_releases: 5

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -132,5 +132,5 @@
   environment: "{{ project_environment }}"
 
 - name: Finalize the deploy
-  deploy_helper: path={{ project_root }} release={{ deploy_helper.new_release }} state=finalize
+  deploy_helper: path={{ project_root }} release={{ deploy_helper.new_release }} state=finalize clean={{ project_clean|bool }} keep_releases={{ project_keep_releases|int }}
   when: "{{ project_finalize }}"


### PR DESCRIPTION
`project_clean` translates to the `clean` option of the deploy_helper. `project_keep_releases` translates to the `keep_releases` option of the deploy_helper. The control whether or not old releases are cleaned up when finalizing, and how many releases should be kept.

I went ahead and marked this as version 3.2.0 in the change-log.