### PR TITLE
Ensure directories for shared paths to go into are present

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,13 @@
 ---
 
 ### Initialize
-- name: Include initialize hook 
+- name: Include initialize hook
   include: "{{ project_deploy_hook_on_initialize }}"
   when: project_deploy_hook_on_initialize is defined
 
 - name: Initialize
   deploy_helper: "path={{ project_root }} release={{ project_release|default(omit) }} state=present shared_path={{ project_shared_path }}"
+
 
 ### Update source
 - name: Include update_source hook
@@ -112,7 +113,11 @@
   file: "path='{{ deploy_helper.shared_path }}/{{ item.src }}' state={{ item.type|default('directory') }}"
   with_items: "{{ project_shared_children }}"
 
-- name: Ensure shared paths are absent
+- name: Ensure directories for shared paths to go into are present
+  file: "path={{ [deploy_helper.new_release_path, item.path] | join('/') | dirname }} state=directory recurse=yes"
+  with_items: "{{ project_shared_children }}"
+
+- name: Ensure shared paths themselves are absent
   file: "path='{{ deploy_helper.new_release_path }}/{{ item.path }}' state=absent"
   with_items: "{{ project_shared_children }}"
 


### PR DESCRIPTION
Example:

We need a specific cache directory in the project at `var/cache/twig`, but the project doesn't have the `var/cache` directory yet (only a `var` or maybe not even that).

Currently the task `Ensure shared paths are absent` would fail, because `state=link` needs the target directory to exist.

This PR fixes that issue.