### PR TITLE
Replace deprecated "include" with "include_tasks"

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ project_deploy
 
 Deploy a project with Ansible
 
+### Changelog 4.0.0 BC BREAK. Set your galaxy version to v3.2.0 for Ansible 2.3 or less.
+
+- replaced deprecated "include" with "include_tasks".
+
 ### Changelog 3.2.0
 
 - added the variables "project_clean" and "project_keep_releases".
@@ -73,7 +77,7 @@ simplifying automated rollbacks (you can use the `set_fact` module to create uni
 
 At certain key points in the role an option exists to include a task file of your own.
 In order to use this option, create a tasks file and set the corresponding hook variable to its location:
- 
+
     project_deploy_hook_on_initialize
     project_deploy_hook_on_update_source
     project_deploy_hook_on_create_build_dir
@@ -84,7 +88,7 @@ In order to use this option, create a tasks file and set the corresponding hook 
 **Example:**
 
     project_deploy_hook_on_perform_build: "{{ playbook_dir }}/deploy_hooks/perform-build.yml"
-    
+
 If you use the "git" strategy, you must also set a repository:
 
     project_git_repo: "git_repository"
@@ -171,7 +175,7 @@ You can also change the path of the installed vendors (relative to {{ deploy_hel
     project_bower_components_path: components
 
 
-The project_shared_path is used to set the path for your shared assets. 
+The project_shared_path is used to set the path for your shared assets.
 Required: No
 Default: "{{ project_root }}/shared"
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Deploy software projects (Capistrano-like)
   company: Future500
   license: LGPL
-  min_ansible_version: 1.4
+  min_ansible_version: 2.4
   galaxy_tags:
     - web
   platforms:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 
 ### Initialize
 - name: Include initialize hook
-  include: "{{ project_deploy_hook_on_initialize }}"
+  include_tasks: "{{ project_deploy_hook_on_initialize }}"
   when: project_deploy_hook_on_initialize is defined
 
 - name: Initialize
@@ -11,7 +11,7 @@
 
 ### Update source
 - name: Include update_source hook
-  include: "{{ project_deploy_hook_on_update_source }}"
+  include_tasks: "{{ project_deploy_hook_on_update_source }}"
   when: project_deploy_hook_on_update_source is defined
 
 - name: Clone project files
@@ -32,7 +32,7 @@
 
 ### Create build dir
 - name: Include create_build_dir hook
-  include: "{{ project_deploy_hook_on_create_build_dir }}"
+  include_tasks: "{{ project_deploy_hook_on_create_build_dir }}"
   when: project_deploy_hook_on_create_build_dir is defined
 
 - name: Copy files to new build dir
@@ -53,7 +53,7 @@
 
 ### Perform build
 - name: Include perform_build hook
-  include: "{{ project_deploy_hook_on_perform_build }}"
+  include_tasks: "{{ project_deploy_hook_on_perform_build }}"
   when: project_deploy_hook_on_perform_build is defined
 
 - name: Run pre_build_commands in the new_release_path
@@ -106,7 +106,7 @@
 
 ### Make shared resources
 - name: Include make_shared_resources hook
-  include: "{{ project_deploy_hook_on_make_shared_resources }}"
+  include_tasks: "{{ project_deploy_hook_on_make_shared_resources }}"
   when: project_deploy_hook_on_make_shared_resources is defined
 
 - name: Ensure shared sources are present
@@ -128,7 +128,7 @@
 
 ### Finalize
 - name: Include finalize hook
-  include: "{{ project_deploy_hook_on_finalize }}"
+  include_tasks: "{{ project_deploy_hook_on_finalize }}"
   when: project_deploy_hook_on_finalize is defined
 
 - name: Run post_build_commands in the new_release_path


### PR DESCRIPTION
Starting with Ansible 2.4, we get the following notice when using this role:

```
[DEPRECATION WARNING]: The use of 'include' for tasks has been deprecated. Use
'import_tasks' for static inclusions or 'include_tasks' for dynamic inclusions.
 This feature will be removed in a future release. Deprecation warnings can be
disabled by setting deprecation_warnings=False in ansible.cfg.
```

This PR replaces `include` with `include_tasks`. I'm not using `import_tasks` because that would include the tasks at parse-time (not runtime).

Because it's not compatible with Ansible 2.3 and below, this PR introduces a BC break. When merged, please tag as `v4.0.0`.