### PR TITLE
Ensure copy replaces directories, not copy into them

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,7 +36,7 @@
   when: project_deploy_hook_on_create_build_dir is defined
 
 - name: Copy files to new build dir
-  command: "cp -pr {{ project_source_path }} {{ deploy_helper.new_release_path }}"
+  command: "cp -prT {{ project_source_path }} {{ deploy_helper.new_release_path }}"
 
 - name: Remove unwanted files/folders from new release
   file: "path={{ deploy_helper.new_release_path }}/{{ item }} state=absent"
@@ -67,7 +67,7 @@
   when: project_copy_previous_composer_vendors
 
 - name: Copy vendor dir if exists to speed up composer
-  command: /bin/cp -rp {{ deploy_helper.current_path }}/{{ project_composer_vendor_path }} {{ deploy_helper.new_release_path }}/{{ project_composer_vendor_path }}
+  command: /bin/cp -prT {{ deploy_helper.current_path }}/{{ project_composer_vendor_path }} {{ deploy_helper.new_release_path }}/{{ project_composer_vendor_path }}
   when: project_copy_previous_composer_vendors and check_composer_vendor_path.stat.exists
 
 - name: Do composer install
@@ -81,7 +81,7 @@
   when: project_copy_previous_npm_modules
 
 - name: Copy npm dir if exists to speed up npm install
-  command: /bin/cp -rp {{ deploy_helper.current_path }}/{{ project_npm_modules_path }} {{ deploy_helper.new_release_path }}/{{ project_npm_modules_path }}
+  command: /bin/cp -prT {{ deploy_helper.current_path }}/{{ project_npm_modules_path }} {{ deploy_helper.new_release_path }}/{{ project_npm_modules_path }}
   when: project_copy_previous_npm_modules and check_npm_modules_path.stat.exists
 
 - name: Do npm install
@@ -95,7 +95,7 @@
   when: project_copy_previous_bower_components
 
 - name: Copy bower dir if exists to speed up bower install
-  command: /bin/cp -rp {{ deploy_helper.current_path }}/{{ project_bower_components_path }} {{ deploy_helper.new_release_path }}/{{ project_bower_components_path }}
+  command: /bin/cp -prT {{ deploy_helper.current_path }}/{{ project_bower_components_path }} {{ deploy_helper.new_release_path }}/{{ project_bower_components_path }}
   when: project_copy_previous_bower_components and check_bower_components_path.stat.exists
 
 - name: Do bower install


### PR DESCRIPTION
I've added the `-T` (`--no-target-directory`) to `cp` commands. Together with `-r` (`--recursive`) this ensures when the destination directory already exists, `cp` will **not** place the source _inside_ it.

Given (using Composer as example):

```
$ tree current releases
current
└── vendor
    └── foo
releases
└── 19700101000000
    └── vendor
        └── bar
```

It won't:

```
$ cp -prv current/vendor releases/19700101000000/vendor
'current/vendor' -> 'releases/19700101000000/vendor/vendor'
'current/vendor/foo' -> 'releases/19700101000000/vendor/vendor/foo'
```

But it will:

```
$ cp -prTv current/vendor releases/19700101000000/vendor
'current/vendor/foo' -> 'releases/19700101000000/vendor/foo'
```

This solves the issue that with each run (deploy), these folders get bigger and bigger, because the old folder is copied _inside_ of the new folder (instead of replacing it).

PS: This issue doesn't exist when the destination-directory doesn't exist. It only arises when it _does_ exist.