### PR TITLE
Amazon AWS S3 module update for latests Ansible version

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,7 +33,7 @@
   when: project_deploy_strategy == 'synchronize'
 
 - name: S3 download project files
-  amazon.aws.aws_s3:
+  amazon.aws.s3_object:
     bucket: "{{ project_s3_bucket }}"
     mode: get
     object: "{{ project_s3_path }}/{{ project_s3_filename }}"


### PR DESCRIPTION
Hi

I fixed a deprecated module call to amazon aws module in latest Ansible version. 

See deprecated information
https://docs.ansible.com/ansible/latest/collections/amazon/aws/aws_s3_module.html

To

https://docs.ansible.com/ansible/latest/collections/amazon/aws/s3_object_module.html#ansible-collections-amazon-aws-s3-object-module

