### PR TITLE
Fixes "variable 'community' is undefined"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -196,7 +196,7 @@
 
 - name: Ensure directories for shared paths to go into are present
   ansible.builtin.file:
-    path: "{{ [community.general.deploy_helper.new_release_path, item.path] | join('/') | dirname }}"
+    path: "{{ [deploy_helper.new_release_path, item.path] | join('/') | dirname }}"
     state: directory
     recurse: "yes"
   with_items: "{{ project_shared_children }}"


### PR DESCRIPTION
I'm getting the following error when deploying.

```
FAILED! => {"msg": "The task includes an option with an undefined variable.. 'community' is undefined

The error appears to be in '~/.ansible/roles/f500.project_deploy/tasks/main.yml': line 197, column 3, but may be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:
- name: Ensure directories for shared paths to go into are present here"}
```

This leads me to believe that line 199 in tasks/main.yml is the actual issue
changing this line to 
```
-    path: "{{ [community.general.deploy_helper.new_release_path, item.path] | join('/') | dirname }}"
+    path: "{{ [deploy_helper.new_release_path, item.path] | join('/') | dirname }}"
```
solves the issue

It was last changed here:
https://github.com/f500/ansible-project_deploy/commit/076ffca68cf96eee701ff89a3972d7a33c0546ec#diff-3d0ff1709ca48add100327bb2a468e6c508fb92a159c64c4f99ad1df89d9bddeR199